### PR TITLE
Remove the 0 from the 12 hour format from the 'Digital (bold)' option

### DIFF
--- a/packages/SystemUI/src/com/android/keyguard/KeyguardStatusView.java
+++ b/packages/SystemUI/src/com/android/keyguard/KeyguardStatusView.java
@@ -238,7 +238,7 @@ public class KeyguardStatusView extends GridLayout {
             mClockView.setFormat12Hour(Patterns.clockView12);
             mClockView.setFormat24Hour(Patterns.clockView24);
         } else if (mClockSelection == 1) {
-            mClockView.setFormat12Hour(Html.fromHtml("<strong>hh</strong>mm"));
+            mClockView.setFormat12Hour(Html.fromHtml("<strong>h</strong>mm"));
             mClockView.setFormat24Hour(Html.fromHtml("<strong>kk</strong>mm"));
         } else if (mClockSelection == 5) {
             mClockView.setFormat12Hour(Html.fromHtml("<strong>hh</strong><br>mm"));


### PR DESCRIPTION
This was an oversight when we first pushed the lockscreen clock/date styles.
The 12 clock format should never have a 0 in front of it. That type of format
is reserved for the 24 clock format.

Example of the fail:

If it was 9pm, the clock would show 0900

Change-Id: I8d1b8f785826bfe69f26c6a909421e0911ed6283